### PR TITLE
fix: int/float type mismatch

### DIFF
--- a/UMAPINFODesigner/uio/wadreader.py
+++ b/UMAPINFODesigner/uio/wadreader.py
@@ -117,8 +117,12 @@ def get_waddata_map_image(mapn, width=192):
     ymin = int(ymin * yscale)
 
     for v in edit.vertexes:
-        v.x = v.x * xscale
-        v.y = -v.y * yscale
+        # smeghammer
+        _x =  round(v.x * xscale,None)
+        _y =  round(-v.y * yscale,None)
+
+        v.x =_x
+        v.y = _y
 
     im = Image.new('RGB', ((xmax - xmin) + 8, (ymax - ymin) + 8), (0,0,0))
     draw = ImageDraw.Draw(im)


### PR DESCRIPTION
Map thumbnail was not being rendered. vertexes objects do not play well with floats. Cast scaling result to int.

Tested via CLI and VS Code:
The thumbnail now renders:
![image](https://github.com/user-attachments/assets/0fcf16bf-a00b-4016-895e-afee66c1c775)

